### PR TITLE
feat: 操作マニュアルページの追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,10 @@ import { ProposerProposalFormPage } from "./pages/proposer/ProposerProposalFormP
 import { ProposerProposalDetailPage } from "./pages/proposer/ProposerProposalDetailPage";
 import { DataRequestsPage } from "./pages/proposer/DataRequestsPage";
 import { CommunityProposalsPage } from "./pages/proposer/CommunityProposalsPage";
+import { ManualPage } from "./pages/manual/ManualPage";
+import { HrManualPage } from "./pages/manual/HrManualPage";
+import { ProposerManualPage } from "./pages/manual/ProposerManualPage";
+import { GlossaryPage } from "./pages/manual/GlossaryPage";
 
 export default function App() {
   return (
@@ -33,6 +37,10 @@ export default function App() {
           <Route element={<RequireAuth />}>
             <Route element={<Layout />}>
               <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/manual" element={<ManualPage />} />
+              <Route path="/manual/hr" element={<HrManualPage />} />
+              <Route path="/manual/proposer" element={<ProposerManualPage />} />
+              <Route path="/manual/glossary" element={<GlossaryPage />} />
             </Route>
           </Route>
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -44,6 +44,7 @@ export function Navbar() {
             </div>
           </div>
           <div className="flex items-center gap-4 text-sm">
+            <Link to="/manual" className="hover:text-blue-200">📖 マニュアル</Link>
             <span>{user.display_name}（{user.department}）</span>
             <button onClick={handleLogout} className="hover:text-blue-200">
               ログアウト

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -159,6 +159,22 @@ export function DashboardPage() {
         <p className="text-gray-500 mt-1">
           {isHr ? "データセットとレビューの状況を確認しましょう" : "データの活用状況をチェックしましょう"}
         </p>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <Link
+            to="/manual"
+            className="inline-flex items-center gap-1.5 text-sm bg-white border border-blue-200 text-blue-600 hover:bg-blue-50 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            <span>📖</span>
+            操作マニュアルを見る
+          </Link>
+          <Link
+            to={isHr ? "/manual/hr" : "/manual/proposer"}
+            className="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white hover:bg-blue-700 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            <span>{isHr ? "🏢" : "🔍"}</span>
+            {isHr ? "データオーナー向けマニュアル" : "データ利用者向けマニュアル"}
+          </Link>
+        </div>
       </div>
 
       {/* Summary Stat Cards */}

--- a/src/pages/manual/GlossaryPage.tsx
+++ b/src/pages/manual/GlossaryPage.tsx
@@ -1,0 +1,243 @@
+import { Link } from "react-router-dom";
+
+interface GlossaryTerm {
+  term: string;
+  reading?: string;
+  description: string;
+  category: "data" | "workflow" | "role" | "system";
+  relatedLinks?: { label: string; to: string }[];
+}
+
+const GLOSSARY: GlossaryTerm[] = [
+  {
+    term: "合成データ",
+    reading: "ごうせいデータ",
+    description:
+      "実際の個人情報や機密情報を含まないよう、統計的な性質を保ちながら人工的に生成されたデータ。実データの代わりに分析・研究に使用でき、プライバシーリスクを大幅に低減できます。",
+    category: "data",
+    relatedLinks: [{ label: "データセット一覧（利用者）", to: "/proposer/datasets" }],
+  },
+  {
+    term: "データセット",
+    reading: "データセット",
+    description:
+      "本システムで管理される、合成データの集まり。複数のテーブル（表）から構成されることもあります。データオーナーが管理し、公開されると利用者が閲覧・活用提案できるようになります。",
+    category: "data",
+    relatedLinks: [
+      { label: "データセット管理（オーナー）", to: "/hr/datasets" },
+      { label: "データセット一覧（利用者）", to: "/proposer/datasets" },
+    ],
+  },
+  {
+    term: "カタログ情報",
+    reading: "カタログじょうほう",
+    description:
+      "データセットの説明・タグ・利用規約・テーブル構成・ユースケース例など、データセットの内容を説明するメタ情報。データオーナーが設定・編集します。",
+    category: "data",
+    relatedLinks: [{ label: "カタログ編集（オーナー）", to: "/hr/datasets" }],
+  },
+  {
+    term: "データオーナー",
+    reading: "データオーナー",
+    description:
+      "データセットを管理・公開する責任者。人事部門や情報管理部門のスタッフが該当します。利用提案のレビューや実行管理も担当します。",
+    category: "role",
+    relatedLinks: [{ label: "データオーナー向けマニュアル", to: "/manual/hr" }],
+  },
+  {
+    term: "データ利用者",
+    reading: "データりようしゃ",
+    description:
+      "公開されたデータセットを活用する研究者・分析者。活用提案を作成してデータオーナーのレビューを受け、承認されると実行リクエストを提出できます。",
+    category: "role",
+    relatedLinks: [{ label: "データ利用者向けマニュアル", to: "/manual/proposer" }],
+  },
+  {
+    term: "活用提案",
+    reading: "かつようていあん",
+    description:
+      "データ利用者がデータセットをどのように使いたいかを記述した申請書。目的・使用するデータ・期待する成果・利用期間などを記載してデータオーナーに提出します。承認されると実行リクエストが可能になります。",
+    category: "workflow",
+    relatedLinks: [
+      { label: "マイ提案（利用者）", to: "/proposer/proposals" },
+      { label: "提案レビュー（オーナー）", to: "/hr/proposals" },
+    ],
+  },
+  {
+    term: "実行リクエスト",
+    reading: "じっこうリクエスト",
+    description:
+      "合成データの生成を依頼する申請。活用提案が承認された後、データ利用者が生成するデータの行数・形式・パラメータなどを指定して提出します。",
+    category: "workflow",
+    relatedLinks: [
+      { label: "マイ実行（利用者）", to: "/proposer/submissions" },
+      { label: "実行管理（オーナー）", to: "/hr/submissions" },
+    ],
+  },
+  {
+    term: "データリクエスト",
+    reading: "データリクエスト",
+    description:
+      "まだ存在しないデータセットや、追加してほしいデータの要望をデータオーナーに伝える機能。利用者が必要なデータを明示することで、データオーナーが対応を検討します。",
+    category: "workflow",
+    relatedLinks: [{ label: "データリクエスト", to: "/proposer/data-requests" }],
+  },
+  {
+    term: "レビュー",
+    reading: "レビュー",
+    description:
+      "データオーナーが活用提案や実行リクエストの内容を確認し、承認または却下する作業。提案の目的・利用規約への適合性・安全性などを確認します。",
+    category: "workflow",
+    relatedLinks: [
+      { label: "提案レビュー（オーナー）", to: "/hr/proposals" },
+      { label: "実行管理（オーナー）", to: "/hr/submissions" },
+    ],
+  },
+  {
+    term: "ステータス",
+    reading: "ステータス",
+    description:
+      "提案・実行リクエストの現在の状態。「レビュー待ち」「承認済み」「却下」「実行中」「完了」などがあります。ダッシュボードや各一覧ページで確認できます。",
+    category: "system",
+    relatedLinks: [{ label: "ダッシュボード", to: "/dashboard" }],
+  },
+  {
+    term: "コミュニティ",
+    reading: "コミュニティ",
+    description:
+      "他のユーザーが公開した活用提案を閲覧・参照できる場所。いいねをつけることができ、注目度の高い提案はダッシュボードの「注目のユースケース」に表示されます。",
+    category: "system",
+    relatedLinks: [
+      { label: "コミュニティ（利用者）", to: "/proposer/community" },
+      { label: "ダッシュボード", to: "/dashboard" },
+    ],
+  },
+  {
+    term: "ダッシュボード",
+    reading: "ダッシュボード",
+    description:
+      "ログイン後のトップページ。最近のデータセット・注目の提案・レビュー待ちのワークフローなどを一覧できます。",
+    category: "system",
+    relatedLinks: [{ label: "ダッシュボード", to: "/dashboard" }],
+  },
+  {
+    term: "タグ",
+    reading: "タグ",
+    description:
+      "データセットや提案に付けるキーワード。「人事」「給与」「売上」などのタグを使うことで、関連するデータを検索・分類しやすくなります。",
+    category: "data",
+  },
+  {
+    term: "利用規約",
+    reading: "りようきやく",
+    description:
+      "データセットの利用条件・禁止事項・注意点などを定めたルール。データオーナーが設定し、利用者は必ず内容を確認した上でデータを活用する必要があります。",
+    category: "data",
+    relatedLinks: [{ label: "データセット一覧（利用者）", to: "/proposer/datasets" }],
+  },
+  {
+    term: "ユースケース",
+    reading: "ユースケース",
+    description:
+      "データセットの活用事例・使い方の例。データオーナーがカタログ情報に設定する場合と、コミュニティの活用提案がユースケースとして機能する場合があります。",
+    category: "data",
+    relatedLinks: [{ label: "コミュニティ（利用者）", to: "/proposer/community" }],
+  },
+];
+
+const CATEGORY_LABELS: Record<string, { label: string; color: string; icon: string }> = {
+  data: { label: "データ関連", color: "bg-blue-100 text-blue-700", icon: "🗄️" },
+  workflow: { label: "ワークフロー", color: "bg-orange-100 text-orange-700", icon: "⚙️" },
+  role: { label: "ロール・役割", color: "bg-green-100 text-green-700", icon: "👤" },
+  system: { label: "システム機能", color: "bg-purple-100 text-purple-700", icon: "💻" },
+};
+
+export function GlossaryPage() {
+  const categories = ["role", "data", "workflow", "system"] as const;
+
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-purple-50 to-indigo-50 rounded-2xl p-8 border border-purple-100">
+        <div className="flex items-center gap-3 mb-3">
+          <span className="text-4xl">📚</span>
+          <h1 className="text-3xl font-bold text-gray-800">用語集</h1>
+        </div>
+        <p className="text-gray-600 text-lg mb-4">
+          合成データカタログで使われる用語をわかりやすく解説しています。
+          各用語から関連する操作画面へのリンクもあります。
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Link to="/manual" className="text-sm text-purple-700 hover:underline">← マニュアルトップへ</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/hr" className="text-sm text-purple-700 hover:underline">データオーナー向けマニュアル</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/proposer" className="text-sm text-purple-700 hover:underline">データ利用者向けマニュアル</Link>
+        </div>
+      </div>
+
+      {/* Category Filter Legend */}
+      <div className="flex flex-wrap gap-2">
+        {Object.entries(CATEGORY_LABELS).map(([key, val]) => (
+          <span key={key} className={`${val.color} text-sm px-3 py-1 rounded-full font-medium`}>
+            {val.icon} {val.label}
+          </span>
+        ))}
+      </div>
+
+      {/* Glossary by Category */}
+      {categories.map((cat) => {
+        const terms = GLOSSARY.filter((t) => t.category === cat);
+        const catInfo = CATEGORY_LABELS[cat];
+        return (
+          <section key={cat}>
+            <h2 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
+              <span>{catInfo.icon}</span>
+              {catInfo.label}
+            </h2>
+            <div className="space-y-3">
+              {terms.map((item) => (
+                <div key={item.term} className="bg-white rounded-xl shadow-sm p-5 border border-gray-100">
+                  <div className="flex items-start justify-between gap-4 flex-wrap">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3 mb-2">
+                        <h3 className="text-lg font-bold text-gray-800">{item.term}</h3>
+                        {item.reading && (
+                          <span className="text-xs text-gray-400">（{item.reading}）</span>
+                        )}
+                        <span className={`text-xs px-2 py-0.5 rounded-full ${catInfo.color}`}>
+                          {catInfo.label}
+                        </span>
+                      </div>
+                      <p className="text-gray-600 text-sm leading-relaxed">{item.description}</p>
+                    </div>
+                  </div>
+                  {item.relatedLinks && item.relatedLinks.length > 0 && (
+                    <div className="mt-3 pt-3 border-t border-gray-100 flex flex-wrap gap-2">
+                      <span className="text-xs text-gray-400">関連リンク：</span>
+                      {item.relatedLinks.map((link) => (
+                        <Link
+                          key={link.to}
+                          to={link.to}
+                          className="text-xs text-blue-600 hover:underline bg-blue-50 px-2 py-0.5 rounded-full"
+                        >
+                          {link.label} →
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      {/* Navigation */}
+      <div className="flex justify-between items-center pt-4 border-t border-gray-200">
+        <Link to="/manual" className="text-blue-600 hover:underline text-sm">← マニュアルトップへ</Link>
+        <Link to="/dashboard" className="text-blue-600 hover:underline text-sm">ダッシュボードへ →</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/manual/HrManualPage.tsx
+++ b/src/pages/manual/HrManualPage.tsx
@@ -1,0 +1,292 @@
+import { Link } from "react-router-dom";
+
+function StepCard({
+  step,
+  title,
+  description,
+  icon,
+  color,
+  children,
+  id,
+}: {
+  step: number;
+  title: string;
+  description: string;
+  icon: string;
+  color: string;
+  children?: React.ReactNode;
+  id?: string;
+}) {
+  const colorMap: Record<string, string> = {
+    blue: "border-blue-500 bg-blue-50",
+    green: "border-green-500 bg-green-50",
+    orange: "border-orange-500 bg-orange-50",
+    purple: "border-purple-500 bg-purple-50",
+  };
+  const badgeMap: Record<string, string> = {
+    blue: "bg-blue-500",
+    green: "bg-green-500",
+    orange: "bg-orange-500",
+    purple: "bg-purple-500",
+  };
+
+  return (
+    <div id={id} className={`rounded-xl border-l-4 p-6 ${colorMap[color]}`}>
+      <div className="flex items-start gap-4">
+        <div className={`${badgeMap[color]} text-white rounded-full w-10 h-10 flex items-center justify-center text-lg font-bold shrink-0`}>
+          {step}
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-2xl">{icon}</span>
+            <h3 className="text-lg font-bold text-gray-800">{title}</h3>
+          </div>
+          <p className="text-gray-600 mb-4">{description}</p>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OperationItem({ label, detail, link }: { label: string; detail: string; link?: string }) {
+  return (
+    <div className="bg-white rounded-lg p-3 flex items-start gap-3 shadow-sm">
+      <span className="text-green-500 mt-0.5 shrink-0">✓</span>
+      <div>
+        <div className="font-medium text-gray-800 text-sm">
+          {link ? (
+            <Link to={link} className="text-blue-600 hover:underline">
+              {label}
+            </Link>
+          ) : (
+            label
+          )}
+        </div>
+        <div className="text-xs text-gray-500 mt-0.5">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
+function FlowDiagram() {
+  const steps = [
+    { label: "データセット\n登録・管理", icon: "🗄️", color: "bg-blue-100 border-blue-300" },
+    { label: "カタログ情報\n編集", icon: "✏️", color: "bg-indigo-100 border-indigo-300" },
+    { label: "データセット\n公開", icon: "🌐", color: "bg-green-100 border-green-300" },
+    { label: "利用提案の\nレビュー", icon: "📋", color: "bg-orange-100 border-orange-300" },
+    { label: "実行管理・\n結果確認", icon: "⚙️", color: "bg-purple-100 border-purple-300" },
+  ];
+
+  return (
+    <div className="bg-white rounded-xl p-5 shadow-sm">
+      <h3 className="font-semibold text-gray-700 mb-4 text-center">データオーナーの基本的な流れ</h3>
+      <div className="flex items-center justify-center flex-wrap gap-1">
+        {steps.map((s, i) => (
+          <div key={i} className="flex items-center">
+            <div className={`${s.color} border-2 rounded-xl px-3 py-2 text-center min-w-[90px]`}>
+              <div className="text-2xl mb-1">{s.icon}</div>
+              <div className="text-xs font-medium text-gray-700 whitespace-pre-line">{s.label}</div>
+            </div>
+            {i < steps.length - 1 && (
+              <div className="text-gray-400 text-xl mx-1">→</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function HrManualPage() {
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-2xl p-8 border border-blue-100">
+        <div className="flex items-center gap-3 mb-3">
+          <span className="text-4xl">🏢</span>
+          <h1 className="text-3xl font-bold text-gray-800">データオーナー向けマニュアル</h1>
+        </div>
+        <p className="text-gray-600 text-lg mb-4">
+          人事・データ管理部門の方（データオーナー）向けの操作マニュアルです。
+          データセットの公開・管理から、利用提案のレビューまでを解説します。
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Link to="/manual" className="text-sm text-blue-600 hover:underline">← マニュアルトップへ</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/glossary" className="text-sm text-blue-600 hover:underline">用語集</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/proposer" className="text-sm text-blue-600 hover:underline">データ利用者向けマニュアル</Link>
+        </div>
+      </div>
+
+      {/* Flow Diagram */}
+      <FlowDiagram />
+
+      {/* このマニュアルで学べること */}
+      <div className="bg-blue-50 rounded-xl p-5 border border-blue-100">
+        <h2 className="font-semibold text-blue-800 mb-3">📌 このマニュアルで学べること</h2>
+        <ul className="space-y-1 text-sm text-blue-900">
+          <li>✅ データセットを管理・公開する方法</li>
+          <li>✅ カタログ情報（説明・タグ・利用規約など）を編集する方法</li>
+          <li>✅ データ利用者からの提案をレビュー・承認する方法</li>
+          <li>✅ 合成データの実行状況を確認する方法</li>
+        </ul>
+      </div>
+
+      {/* Step 1 */}
+      <StepCard
+        id="step1"
+        step={1}
+        title="データセット管理"
+        description="あなたの組織が持つデータセットを管理します。一覧から各データセットの状態を確認できます。"
+        icon="🗄️"
+        color="blue"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="データセット一覧を見る"
+            detail="「データセット」メニューから全データセットの一覧を確認できます。公開状態も一目でわかります。"
+            link="/hr/datasets"
+          />
+          <OperationItem
+            label="データセットの詳細を確認する"
+            detail="データセット名をクリックすると、詳細情報（テーブル構成・ユースケース・提出履歴など）を確認できます。"
+          />
+          <OperationItem
+            label="公開・非公開を切り替える"
+            detail="詳細ページの「公開する」ボタンでデータを公開できます。公開するとデータ利用者がアクセスできるようになります。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-blue-200 text-sm">
+          <p className="font-medium text-blue-800 mb-1">💡 ポイント</p>
+          <p className="text-gray-600">
+            データセットを公開する前に、必ずカタログ情報（Step 2）を整備しましょう。
+            説明・タグ・利用規約が揃っていると、データ利用者が活用しやすくなります。
+          </p>
+        </div>
+      </StepCard>
+
+      {/* Step 2 */}
+      <StepCard
+        id="step2"
+        step={2}
+        title="カタログ情報の編集"
+        description="データセットの説明・タグ・利用規約などのカタログ情報を編集します。わかりやすい情報を提供することで、適切な活用を促進できます。"
+        icon="✏️"
+        color="blue"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="カタログ情報を編集する"
+            detail="データセット詳細ページの「カタログ編集」ボタンから、説明・タグ・利用規約・サンプルデータなどを設定できます。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-blue-200">
+          <p className="font-medium text-blue-800 mb-2 text-sm">📝 設定できる情報</p>
+          <div className="grid grid-cols-2 gap-2 text-xs text-gray-600">
+            <div className="flex items-center gap-1"><span>🏷️</span> データセット名・説明</div>
+            <div className="flex items-center gap-1"><span>🔖</span> タグ（検索用キーワード）</div>
+            <div className="flex items-center gap-1"><span>📄</span> 利用規約・注意事項</div>
+            <div className="flex items-center gap-1"><span>📊</span> サンプルデータ・テーブル情報</div>
+            <div className="flex items-center gap-1"><span>💡</span> ユースケース例</div>
+            <div className="flex items-center gap-1"><span>📅</span> データ更新日・有効期限</div>
+          </div>
+        </div>
+      </StepCard>
+
+      {/* Step 3 */}
+      <StepCard
+        id="step3"
+        step={3}
+        title="提案のレビュー"
+        description="データ利用者からの活用提案をレビュー・承認します。提案内容を確認して、適切かどうかを判断してください。"
+        icon="📋"
+        color="orange"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="提案一覧を確認する"
+            detail="「提案レビュー」メニューから、提出された全提案を確認できます。ステータスで「レビュー待ち」を絞り込めます。"
+            link="/hr/proposals"
+          />
+          <OperationItem
+            label="提案の詳細を確認する"
+            detail="提案をクリックすると、目的・使用するデータ・期待する成果などの詳細情報を確認できます。"
+          />
+          <OperationItem
+            label="承認・却下する"
+            detail="提案内容を確認後、「承認」または「却下」ボタンで対応します。コメントを添えて理由を伝えることができます。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-orange-200">
+          <p className="font-medium text-orange-800 mb-2 text-sm">⚠️ レビューの判断ポイント</p>
+          <ul className="text-xs text-gray-600 space-y-1">
+            <li>• 提案の目的は明確ですか？</li>
+            <li>• 利用規約に沿った使い方ですか？</li>
+            <li>• 個人情報・機密情報の取り扱いは適切ですか？</li>
+            <li>• 実現可能な内容ですか？</li>
+          </ul>
+        </div>
+      </StepCard>
+
+      {/* Step 4 */}
+      <StepCard
+        id="step4"
+        step={4}
+        title="実行管理"
+        description="合成データの生成・実行の状況を管理します。提出された実行リクエストをレビューし、結果を確認できます。"
+        icon="⚙️"
+        color="purple"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="実行一覧を確認する"
+            detail="「実行管理」メニューから、すべての実行リクエストの状況を確認できます。"
+            link="/hr/submissions"
+          />
+          <OperationItem
+            label="実行の詳細を確認する"
+            detail="実行をクリックすると、使用したパラメータ・実行結果・ダウンロードリンクなどを確認できます。"
+          />
+          <OperationItem
+            label="実行リクエストを承認・却下する"
+            detail="実行前にレビューが必要な場合、承認または却下の対応を行います。"
+          />
+        </div>
+      </StepCard>
+
+      {/* FAQ */}
+      <div className="bg-gray-50 rounded-xl p-6">
+        <h2 className="text-lg font-bold text-gray-800 mb-4">❓ よくある質問</h2>
+        <div className="space-y-4">
+          {[
+            {
+              q: "データセットを公開したあと、非公開に戻せますか？",
+              a: "はい、データセット詳細ページから「非公開にする」ボタンで非公開に戻せます。非公開にすると、データ利用者はアクセスできなくなります。",
+            },
+            {
+              q: "提案を承認したら、次に何をすればいいですか？",
+              a: "承認後、データ利用者が実行リクエストを提出します。実行管理ページで状況を確認し、必要に応じてレビューを行ってください。",
+            },
+            {
+              q: "複数の担当者でレビューできますか？",
+              a: "現在のシステムでは、データオーナーロールを持つすべてのユーザーが提案・実行のレビューを行えます。",
+            },
+          ].map((faq, i) => (
+            <div key={i} className="bg-white rounded-lg p-4 shadow-sm">
+              <p className="font-medium text-gray-800 mb-1">Q. {faq.q}</p>
+              <p className="text-sm text-gray-600">A. {faq.a}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between items-center pt-4 border-t border-gray-200">
+        <Link to="/manual" className="text-blue-600 hover:underline text-sm">← マニュアルトップへ</Link>
+        <Link to="/manual/proposer" className="text-blue-600 hover:underline text-sm">データ利用者向けマニュアル →</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/manual/ManualPage.tsx
+++ b/src/pages/manual/ManualPage.tsx
@@ -1,0 +1,131 @@
+import { Link } from "react-router-dom";
+import { loadState } from "../../store/session";
+import { USERS } from "../../data/users";
+
+export function ManualPage() {
+  const state = loadState();
+  const user = USERS.find((u) => u.user_id === state.currentUserId);
+  const isHr = user?.role === "hr";
+
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-indigo-50 to-blue-50 rounded-2xl p-8 border border-indigo-100">
+        <div className="flex items-center gap-3 mb-3">
+          <span className="text-4xl">📖</span>
+          <h1 className="text-3xl font-bold text-gray-800">操作マニュアル</h1>
+        </div>
+        <p className="text-gray-600 text-lg">
+          合成データカタログの使い方をわかりやすく解説しています。
+          あなたの役割に合ったマニュアルをご覧ください。
+        </p>
+      </div>
+
+      {/* Role-based recommendation */}
+      {user && (
+        <div className="bg-green-50 border border-green-200 rounded-xl p-4 flex items-center gap-3">
+          <span className="text-2xl">👤</span>
+          <div>
+            <p className="font-semibold text-green-800">
+              {user.display_name}さん（{isHr ? "データオーナー" : "データ利用者"}）向けのマニュアル
+            </p>
+            <p className="text-sm text-green-700 mt-0.5">
+              あなたには{" "}
+              <Link
+                to={isHr ? "/manual/hr" : "/manual/proposer"}
+                className="font-bold underline"
+              >
+                {isHr ? "データオーナー向けマニュアル" : "データ利用者向けマニュアル"}
+              </Link>{" "}
+              がおすすめです。
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Manual Cards */}
+      <div className="grid md:grid-cols-2 gap-6">
+        <Link
+          to="/manual/hr"
+          className="group bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all border-t-4 border-blue-500 p-6 flex flex-col"
+        >
+          <div className="text-5xl mb-4">🏢</div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2 group-hover:text-blue-600 transition-colors">
+            データオーナー向けマニュアル
+          </h2>
+          <p className="text-gray-500 text-sm flex-1">
+            人事・データ管理部門の方向け。データセットの公開・管理、
+            利用提案のレビュー、実行管理などの操作手順を解説します。
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {["データセット管理", "提案レビュー", "実行管理", "カタログ編集"].map((tag) => (
+              <span key={tag} className="text-xs bg-blue-50 text-blue-600 px-2 py-1 rounded-full">
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div className="mt-4 text-blue-600 text-sm font-medium group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
+            マニュアルを見る →
+          </div>
+        </Link>
+
+        <Link
+          to="/manual/proposer"
+          className="group bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all border-t-4 border-green-500 p-6 flex flex-col"
+        >
+          <div className="text-5xl mb-4">🔍</div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2 group-hover:text-green-600 transition-colors">
+            データ利用者向けマニュアル
+          </h2>
+          <p className="text-gray-500 text-sm flex-1">
+            データを活用したい研究者・分析者の方向け。データセットの探し方、
+            活用提案の作成、合成データの実行リクエストなどを解説します。
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {["データ検索", "活用提案", "実行リクエスト", "コミュニティ"].map((tag) => (
+              <span key={tag} className="text-xs bg-green-50 text-green-600 px-2 py-1 rounded-full">
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div className="mt-4 text-green-600 text-sm font-medium group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
+            マニュアルを見る →
+          </div>
+        </Link>
+      </div>
+
+      {/* Glossary Card */}
+      <Link
+        to="/manual/glossary"
+        className="group block bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all border-t-4 border-purple-400 p-6"
+      >
+        <div className="flex items-center gap-4">
+          <div className="text-5xl">📚</div>
+          <div className="flex-1">
+            <h2 className="text-xl font-bold text-gray-800 mb-1 group-hover:text-purple-600 transition-colors">
+              用語集
+            </h2>
+            <p className="text-gray-500 text-sm">
+              システムで使われている専門用語をわかりやすく解説しています。
+              各用語から関連する操作手順へのリンクもあります。
+            </p>
+          </div>
+          <div className="text-purple-600 text-sm font-medium group-hover:translate-x-1 transition-transform">
+            →
+          </div>
+        </div>
+      </Link>
+
+      {/* Quick Links */}
+      <div className="bg-gray-50 rounded-xl p-5">
+        <h2 className="font-semibold text-gray-700 mb-3">クイックリンク</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
+          <Link to="/dashboard" className="text-blue-600 hover:underline">ダッシュボードへ戻る</Link>
+          <Link to="/manual/hr#step1" className="text-blue-600 hover:underline">データセット管理</Link>
+          <Link to="/manual/proposer#step1" className="text-blue-600 hover:underline">データを探す</Link>
+          <Link to="/manual/glossary" className="text-blue-600 hover:underline">用語を調べる</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/manual/ProposerManualPage.tsx
+++ b/src/pages/manual/ProposerManualPage.tsx
@@ -1,0 +1,338 @@
+import { Link } from "react-router-dom";
+
+function StepCard({
+  step,
+  title,
+  description,
+  icon,
+  color,
+  children,
+  id,
+}: {
+  step: number;
+  title: string;
+  description: string;
+  icon: string;
+  color: string;
+  children?: React.ReactNode;
+  id?: string;
+}) {
+  const colorMap: Record<string, string> = {
+    blue: "border-blue-500 bg-blue-50",
+    green: "border-green-500 bg-green-50",
+    orange: "border-orange-500 bg-orange-50",
+    purple: "border-purple-500 bg-purple-50",
+    teal: "border-teal-500 bg-teal-50",
+  };
+  const badgeMap: Record<string, string> = {
+    blue: "bg-blue-500",
+    green: "bg-green-500",
+    orange: "bg-orange-500",
+    purple: "bg-purple-500",
+    teal: "bg-teal-500",
+  };
+
+  return (
+    <div id={id} className={`rounded-xl border-l-4 p-6 ${colorMap[color]}`}>
+      <div className="flex items-start gap-4">
+        <div className={`${badgeMap[color]} text-white rounded-full w-10 h-10 flex items-center justify-center text-lg font-bold shrink-0`}>
+          {step}
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-2xl">{icon}</span>
+            <h3 className="text-lg font-bold text-gray-800">{title}</h3>
+          </div>
+          <p className="text-gray-600 mb-4">{description}</p>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OperationItem({ label, detail, link }: { label: string; detail: string; link?: string }) {
+  return (
+    <div className="bg-white rounded-lg p-3 flex items-start gap-3 shadow-sm">
+      <span className="text-green-500 mt-0.5 shrink-0">✓</span>
+      <div>
+        <div className="font-medium text-gray-800 text-sm">
+          {link ? (
+            <Link to={link} className="text-blue-600 hover:underline">
+              {label}
+            </Link>
+          ) : (
+            label
+          )}
+        </div>
+        <div className="text-xs text-gray-500 mt-0.5">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
+function FlowDiagram() {
+  const steps = [
+    { label: "データセットを\n探す", icon: "🔍", color: "bg-blue-100 border-blue-300" },
+    { label: "活用提案を\n作成", icon: "💡", color: "bg-green-100 border-green-300" },
+    { label: "レビュー待ち\n（承認待ち）", icon: "⏳", color: "bg-orange-100 border-orange-300" },
+    { label: "実行リクエスト\nを提出", icon: "🚀", color: "bg-purple-100 border-purple-300" },
+    { label: "結果を\n確認・活用", icon: "📊", color: "bg-teal-100 border-teal-300" },
+  ];
+
+  return (
+    <div className="bg-white rounded-xl p-5 shadow-sm">
+      <h3 className="font-semibold text-gray-700 mb-4 text-center">データ利用者の基本的な流れ</h3>
+      <div className="flex items-center justify-center flex-wrap gap-1">
+        {steps.map((s, i) => (
+          <div key={i} className="flex items-center">
+            <div className={`${s.color} border-2 rounded-xl px-3 py-2 text-center min-w-[90px]`}>
+              <div className="text-2xl mb-1">{s.icon}</div>
+              <div className="text-xs font-medium text-gray-700 whitespace-pre-line">{s.label}</div>
+            </div>
+            {i < steps.length - 1 && (
+              <div className="text-gray-400 text-xl mx-1">→</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ProposerManualPage() {
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-green-50 to-teal-50 rounded-2xl p-8 border border-green-100">
+        <div className="flex items-center gap-3 mb-3">
+          <span className="text-4xl">🔍</span>
+          <h1 className="text-3xl font-bold text-gray-800">データ利用者向けマニュアル</h1>
+        </div>
+        <p className="text-gray-600 text-lg mb-4">
+          データを活用したい研究者・分析者（データ利用者）向けの操作マニュアルです。
+          データセットの探し方から、合成データの活用までを解説します。
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Link to="/manual" className="text-sm text-green-700 hover:underline">← マニュアルトップへ</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/glossary" className="text-sm text-green-700 hover:underline">用語集</Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/manual/hr" className="text-sm text-green-700 hover:underline">データオーナー向けマニュアル</Link>
+        </div>
+      </div>
+
+      {/* Flow Diagram */}
+      <FlowDiagram />
+
+      {/* このマニュアルで学べること */}
+      <div className="bg-green-50 rounded-xl p-5 border border-green-100">
+        <h2 className="font-semibold text-green-800 mb-3">📌 このマニュアルで学べること</h2>
+        <ul className="space-y-1 text-sm text-green-900">
+          <li>✅ データセットを探して内容を確認する方法</li>
+          <li>✅ データの活用提案を作成・提出する方法</li>
+          <li>✅ データリクエストを送る方法</li>
+          <li>✅ 合成データの実行リクエストを提出する方法</li>
+          <li>✅ コミュニティの提案を参照・いいねする方法</li>
+        </ul>
+      </div>
+
+      {/* Step 1 */}
+      <StepCard
+        id="step1"
+        step={1}
+        title="データセットを探す"
+        description="活用したいデータセットを見つけます。一覧から内容を確認し、自分の目的に合ったデータセットを選びましょう。"
+        icon="🔍"
+        color="blue"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="データセット一覧を見る"
+            detail="「データセット」メニューから公開されているデータセットの一覧を確認できます。"
+            link="/proposer/datasets"
+          />
+          <OperationItem
+            label="データセットの詳細を確認する"
+            detail="データセット名をクリックすると、テーブル構成・利用規約・ユースケース例・サンプルデータなどの詳細情報を確認できます。"
+          />
+          <OperationItem
+            label="いいねをつける"
+            detail="興味のあるデータセットにいいね（♡）をつけると、コミュニティへの関心度を示せます。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-blue-200 text-sm">
+          <p className="font-medium text-blue-800 mb-1">💡 データセット選びのポイント</p>
+          <p className="text-gray-600">
+            詳細ページの「利用規約」「注意事項」を必ず確認してください。
+            利用目的がデータオーナーの意図と合致しているかどうかも重要です。
+          </p>
+        </div>
+      </StepCard>
+
+      {/* Step 2 */}
+      <StepCard
+        id="step2"
+        step={2}
+        title="活用提案を作成する"
+        description="データセットをどのように活用したいかを提案書にまとめて提出します。データオーナーのレビューを経て承認されます。"
+        icon="💡"
+        color="green"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="マイ提案を管理する"
+            detail="「マイ提案」メニューから自分の提案一覧を確認・管理できます。"
+            link="/proposer/proposals"
+          />
+          <OperationItem
+            label="新しい提案を作成する"
+            detail="「新規提案」ボタンから提案書を作成します。タイトル・目的・使用するデータセット・期待する成果などを入力します。"
+            link="/proposer/proposals/new"
+          />
+          <OperationItem
+            label="提案の状態を確認する"
+            detail="提案を提出すると「レビュー待ち」状態になります。データオーナーがレビューすると「承認」または「却下」に変わります。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-green-200">
+          <p className="font-medium text-green-800 mb-2 text-sm">📝 良い提案書のポイント</p>
+          <ul className="text-xs text-gray-600 space-y-1">
+            <li>• <strong>目的を明確に：</strong>何のためにデータを使うのか具体的に書く</li>
+            <li>• <strong>成果を示す：</strong>どんな分析・研究をしたいかを説明する</li>
+            <li>• <strong>利用期間を記載：</strong>いつまでデータを使う予定か伝える</li>
+            <li>• <strong>セキュリティに配慮：</strong>データの管理方法・共有範囲を明示する</li>
+          </ul>
+        </div>
+      </StepCard>
+
+      {/* Step 3 */}
+      <StepCard
+        id="step3"
+        step={3}
+        title="データリクエストを送る"
+        description="まだ公開されていないデータが必要な場合や、特定のデータを要望したい場合は、データリクエストを送ることができます。"
+        icon="📨"
+        color="orange"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="データリクエスト一覧を見る"
+            detail="「データリクエスト」メニューから過去のリクエスト状況を確認できます。"
+            link="/proposer/data-requests"
+          />
+          <OperationItem
+            label="新しいリクエストを送る"
+            detail="必要なデータの内容・理由・利用目的などを記入して送信します。データオーナーが確認・対応します。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-orange-200 text-sm">
+          <p className="font-medium text-orange-800 mb-1">💡 リクエストのコツ</p>
+          <p className="text-gray-600">
+            なぜそのデータが必要なのかを具体的に書くと、データオーナーに伝わりやすくなります。
+            既存のデータセットで代替できないかも確認してみましょう。
+          </p>
+        </div>
+      </StepCard>
+
+      {/* Step 4 */}
+      <StepCard
+        id="step4"
+        step={4}
+        title="実行リクエストを提出する"
+        description="提案が承認されたら、合成データの実行リクエストを提出します。パラメータを設定して生成を依頼します。"
+        icon="🚀"
+        color="purple"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="マイ実行を管理する"
+            detail="「マイ実行」メニューから自分の実行リクエスト一覧を確認できます。"
+            link="/proposer/submissions"
+          />
+          <OperationItem
+            label="新しい実行リクエストを作成する"
+            detail="「新規実行」ボタンから実行リクエストを作成します。使用するデータセット・行数・ファイル形式などのパラメータを設定します。"
+            link="/proposer/submissions/new"
+          />
+          <OperationItem
+            label="実行結果を確認する"
+            detail="実行が完了すると「完了」状態になります。結果ファイルのダウンロードリンクが表示されます。"
+          />
+        </div>
+        <div className="mt-4 bg-white rounded-lg p-3 border border-purple-200">
+          <p className="font-medium text-purple-800 mb-2 text-sm">⚙️ 実行パラメータについて</p>
+          <div className="grid grid-cols-2 gap-2 text-xs text-gray-600">
+            <div className="flex items-center gap-1"><span>📊</span> 生成するデータの行数</div>
+            <div className="flex items-center gap-1"><span>📁</span> 出力ファイル形式（CSV/JSON等）</div>
+            <div className="flex items-center gap-1"><span>🔀</span> ランダムシード値</div>
+            <div className="flex items-center gap-1"><span>📅</span> データの期間・範囲</div>
+          </div>
+        </div>
+      </StepCard>
+
+      {/* Community */}
+      <StepCard
+        id="community"
+        step={5}
+        title="コミュニティを活用する"
+        description="他のユーザーの提案を参照したり、いいねをつけてコミュニティ活動に参加しましょう。"
+        icon="🌐"
+        color="teal"
+      >
+        <div className="space-y-2">
+          <OperationItem
+            label="コミュニティ提案を見る"
+            detail="「コミュニティ」メニューから他のユーザーが公開した提案を閲覧できます。活用事例の参考になります。"
+            link="/proposer/community"
+          />
+          <OperationItem
+            label="提案にいいねをつける"
+            detail="興味のある提案にいいね（♡）をつけることで、コミュニティでの注目度が上がります。"
+          />
+          <OperationItem
+            label="注目の提案を確認する"
+            detail="ダッシュボードの「注目のユースケース」セクションで、人気の提案をまとめて確認できます。"
+            link="/dashboard"
+          />
+        </div>
+      </StepCard>
+
+      {/* FAQ */}
+      <div className="bg-gray-50 rounded-xl p-6">
+        <h2 className="text-lg font-bold text-gray-800 mb-4">❓ よくある質問</h2>
+        <div className="space-y-4">
+          {[
+            {
+              q: "提案が却下されたらどうすればいいですか？",
+              a: "却下理由を確認し、内容を修正して再提出することができます。データオーナーからのコメントを参考に、提案内容を改善してください。",
+            },
+            {
+              q: "欲しいデータセットが見当たりません",
+              a: "「データリクエスト」機能を使って、データオーナーに新しいデータセットの作成を依頼できます。",
+            },
+            {
+              q: "実行がなかなか完了しません",
+              a: "合成データの生成には時間がかかる場合があります。「マイ実行」ページで状態を確認してください。「処理中」の場合はしばらくお待ちください。",
+            },
+            {
+              q: "他の人の提案内容を参考にできますか？",
+              a: "はい、「コミュニティ」ページで承認済みの提案を閲覧できます。同様のユースケースを参考に提案を作成しましょう。",
+            },
+          ].map((faq, i) => (
+            <div key={i} className="bg-white rounded-lg p-4 shadow-sm">
+              <p className="font-medium text-gray-800 mb-1">Q. {faq.q}</p>
+              <p className="text-sm text-gray-600">A. {faq.a}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between items-center pt-4 border-t border-gray-200">
+        <Link to="/manual/hr" className="text-blue-600 hover:underline text-sm">← データオーナー向けマニュアル</Link>
+        <Link to="/manual/glossary" className="text-blue-600 hover:underline text-sm">用語集 →</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- マニュアルトップページ (ManualPage) を追加
- データオーナー向けマニュアル (HrManualPage) を追加
- データ利用者向けマニュアル (ProposerManualPage) を追加
- 用語集ページ (GlossaryPage) を追加
- ナビバーに「マニュアル」リンクを追加
- ダッシュボードのウェルカムバナーにマニュアルへの導線を追加
- ルーター設定を更新して /manual/* を追加