### PR TITLE
feat: 提案詳細ページに分析結果の図表を追加

### DIFF
--- a/src/components/common/ProposalCharts.tsx
+++ b/src/components/common/ProposalCharts.tsx
@@ -1,0 +1,36 @@
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Title, Tooltip, Legend } from "chart.js";
+import { Bar, Line, Pie, Doughnut } from "react-chartjs-2";
+import { DatasetGraph } from "../../types/models";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Title, Tooltip, Legend);
+
+function GraphRenderer({ graph }: { graph: DatasetGraph }) {
+  const data = { labels: graph.labels, datasets: graph.datasets };
+  const options = { responsive: true, maintainAspectRatio: false, plugins: { title: { display: true, text: graph.title } } };
+
+  return (
+    <div style={{ height: 300 }}>
+      {graph.type === "bar" && <Bar data={data} options={options} />}
+      {graph.type === "line" && <Line data={data} options={options} />}
+      {graph.type === "pie" && <Pie data={data} options={options} />}
+      {graph.type === "doughnut" && <Doughnut data={data} options={options} />}
+    </div>
+  );
+}
+
+export function ProposalCharts({ charts }: { charts: DatasetGraph[] }) {
+  if (charts.length === 0) return null;
+
+  return (
+    <section className="bg-white rounded-lg shadow p-6 mb-6">
+      <h2 className="text-lg font-semibold mb-4">分析結果の図表</h2>
+      <div className={charts.length === 1 ? "" : "grid gap-6 md:grid-cols-2"}>
+        {charts.map((chart) => (
+          <div key={chart.id} className="border border-gray-100 rounded-lg p-4">
+            <GraphRenderer graph={chart} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/data/proposals.ts
+++ b/src/data/proposals.ts
@@ -1,4 +1,4 @@
-import { Proposal } from "../types/models";
+import { DatasetGraph, Proposal } from "../types/models";
 
 export const PROPOSALS: Proposal[] = [
   {
@@ -99,6 +99,36 @@ def main():
 
 if __name__ == "__main__":
     main()`,
+    charts: [
+      {
+        id: "prop001-chart-1",
+        title: "部門別 平均スキルスコア",
+        type: "bar",
+        labels: ["【サンプル】システム開発部", "【サンプル】経営企画部", "【サンプル】法人営業部"],
+        datasets: [
+          {
+            label: "平均スキルスコア",
+            data: [72.3, 81.5, 68.9],
+            backgroundColor: "rgba(59, 130, 246, 0.6)",
+            borderColor: "rgb(59, 130, 246)",
+          },
+        ],
+      },
+      {
+        id: "prop001-chart-2",
+        title: "部門別 スキルスコアのばらつき（標準偏差）",
+        type: "bar",
+        labels: ["【サンプル】システム開発部", "【サンプル】経営企画部", "【サンプル】法人営業部"],
+        datasets: [
+          {
+            label: "標準偏差",
+            data: [15.2, 8.7, 12.1],
+            backgroundColor: "rgba(249, 115, 22, 0.6)",
+            borderColor: "rgb(249, 115, 22)",
+          },
+        ],
+      },
+    ] as DatasetGraph[],
     status: "approved",
     reviews: [
       {
@@ -443,6 +473,41 @@ def main():
 
 if __name__ == "__main__":
     main()`,
+    charts: [
+      {
+        id: "prop004-chart-1",
+        title: "顧客セグメント構成比",
+        type: "doughnut",
+        labels: ["VIP顧客", "アクティブ顧客", "一般顧客", "新規顧客", "休眠顧客"],
+        datasets: [
+          {
+            label: "構成比",
+            data: [12, 28, 20, 25, 15],
+            backgroundColor: [
+              "rgba(239, 68, 68, 0.7)",
+              "rgba(59, 130, 246, 0.7)",
+              "rgba(34, 197, 94, 0.7)",
+              "rgba(168, 85, 247, 0.7)",
+              "rgba(156, 163, 175, 0.7)",
+            ],
+          },
+        ],
+      },
+      {
+        id: "prop004-chart-2",
+        title: "セグメント別 月平均取引額（万円）",
+        type: "bar",
+        labels: ["VIP顧客", "アクティブ顧客", "一般顧客", "新規顧客", "休眠顧客"],
+        datasets: [
+          {
+            label: "月平均取引額（万円）",
+            data: [45, 18, 8, 5, 2],
+            backgroundColor: "rgba(59, 130, 246, 0.6)",
+            borderColor: "rgb(59, 130, 246)",
+          },
+        ],
+      },
+    ] as DatasetGraph[],
     status: "approved",
     reviews: [
       {
@@ -1461,6 +1526,39 @@ def main():
 
 if __name__ == "__main__":
     main()`,
+    charts: [
+      {
+        id: "prop012-chart-1",
+        title: "異常種別の分布",
+        type: "doughnut",
+        labels: ["高額異常", "頻度異常", "パターン異常"],
+        datasets: [
+          {
+            label: "検出件数",
+            data: [68, 45, 39],
+            backgroundColor: [
+              "rgba(239, 68, 68, 0.7)",
+              "rgba(249, 115, 22, 0.7)",
+              "rgba(234, 179, 8, 0.7)",
+            ],
+          },
+        ],
+      },
+      {
+        id: "prop012-chart-2",
+        title: "異常スコア別 検出件数",
+        type: "bar",
+        labels: ["0.5-0.6", "0.6-0.7", "0.7-0.8", "0.8-0.9", "0.9-1.0"],
+        datasets: [
+          {
+            label: "検出件数",
+            data: [42, 35, 28, 22, 25],
+            backgroundColor: "rgba(239, 68, 68, 0.6)",
+            borderColor: "rgb(239, 68, 68)",
+          },
+        ],
+      },
+    ] as DatasetGraph[],
     status: "approved",
     reviews: [
       {

--- a/src/pages/hr/HrProposalDetailPage.tsx
+++ b/src/pages/hr/HrProposalDetailPage.tsx
@@ -11,6 +11,7 @@ import { useToast } from "../../components/common/Toast";
 import { formatDate } from "../../utils/format";
 import { getDatasetName, getEffectiveProposalStatus } from "../../utils/data";
 import { ReviewAction, ReviewComment, ProposalStatus } from "../../types/models";
+import { ProposalCharts } from "../../components/common/ProposalCharts";
 
 const proseClasses = "prose prose-sm max-w-none prose-headings:text-gray-800 prose-p:text-gray-700 prose-strong:text-gray-800 prose-table:text-sm prose-th:bg-gray-50 prose-th:border prose-th:border-gray-200 prose-th:px-3 prose-th:py-1.5 prose-td:border prose-td:border-gray-200 prose-td:px-3 prose-td:py-1.5";
 
@@ -130,6 +131,11 @@ export function HrProposalDetailPage() {
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{proposal.next_steps}</ReactMarkdown>
         </div>
       </section>
+
+      {/* 分析結果の図表 */}
+      {proposal.charts && proposal.charts.length > 0 && (
+        <ProposalCharts charts={proposal.charts} />
+      )}
 
       {/* 技術詳細（折りたたみ） */}
       <CollapsibleSection title="技術詳細">

--- a/src/pages/hr/HrProposalsPage.tsx
+++ b/src/pages/hr/HrProposalsPage.tsx
@@ -16,7 +16,14 @@ export function HrProposalsPage() {
         <DataTable
           columns={[
             { header: "提案ID", accessor: (p) => p.proposal_id },
-            { header: "タイトル", accessor: (p) => p.title },
+            { header: "タイトル", accessor: (p) => (
+              <span className="flex items-center gap-2">
+                {p.title}
+                {p.charts && p.charts.length > 0 && (
+                  <span className="inline-flex items-center bg-indigo-100 text-indigo-700 text-xs px-1.5 py-0.5 rounded font-medium whitespace-nowrap">図表あり</span>
+                )}
+              </span>
+            ) },
             { header: "提案者", accessor: (p) => getUserDisplayName(p.user_id) },
             { header: "データセット", accessor: (p) => getDatasetName(p.dataset_id) },
             { header: "ステータス", accessor: (p) => <StatusBadge status={getEffectiveProposalStatus(state, p)} /> },

--- a/src/pages/proposer/CommunityProposalsPage.tsx
+++ b/src/pages/proposer/CommunityProposalsPage.tsx
@@ -84,6 +84,9 @@ export function CommunityProposalsPage() {
                 <div className="flex items-start justify-between gap-2 mb-2">
                   <h2 className="font-semibold text-gray-900 text-sm leading-snug flex-1">
                     {proposal.title}
+                    {proposal.charts && proposal.charts.length > 0 && (
+                      <span className="ml-2 inline-flex items-center bg-indigo-100 text-indigo-700 text-xs px-1.5 py-0.5 rounded font-medium align-middle">図表あり</span>
+                    )}
                   </h2>
                   <StatusBadge status={status} />
                   {proposal.user_id === state.currentUserId && (

--- a/src/pages/proposer/ProposerProposalDetailPage.tsx
+++ b/src/pages/proposer/ProposerProposalDetailPage.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from "../../components/common/StatusBadge";
 import { ReviewList } from "../../components/common/ReviewList";
 import { formatDate } from "../../utils/format";
 import { getDatasetName, getUserDisplayName, getProposalLikeCount, getEffectiveProposalStatus } from "../../utils/data";
+import { ProposalCharts } from "../../components/common/ProposalCharts";
 
 const proseClasses = "prose prose-sm max-w-none prose-headings:text-gray-800 prose-p:text-gray-700 prose-strong:text-gray-800 prose-table:text-sm prose-th:bg-gray-50 prose-th:border prose-th:border-gray-200 prose-th:px-3 prose-th:py-1.5 prose-td:border prose-td:border-gray-200 prose-td:px-3 prose-td:py-1.5";
 
@@ -121,6 +122,11 @@ export function ProposerProposalDetailPage() {
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{proposal.next_steps}</ReactMarkdown>
         </div>
       </section>
+
+      {/* 分析結果の図表 */}
+      {proposal.charts && proposal.charts.length > 0 && (
+        <ProposalCharts charts={proposal.charts} />
+      )}
 
       {/* 技術詳細（折りたたみ） */}
       <CollapsibleSection title="技術詳細">

--- a/src/pages/proposer/ProposerProposalsPage.tsx
+++ b/src/pages/proposer/ProposerProposalsPage.tsx
@@ -24,7 +24,14 @@ export function ProposerProposalsPage() {
         <DataTable
           columns={[
             { header: "提案ID", accessor: (p) => p.proposal_id },
-            { header: "タイトル", accessor: (p) => p.title },
+            { header: "タイトル", accessor: (p) => (
+              <span className="flex items-center gap-2">
+                {p.title}
+                {p.charts && p.charts.length > 0 && (
+                  <span className="inline-flex items-center bg-indigo-100 text-indigo-700 text-xs px-1.5 py-0.5 rounded font-medium whitespace-nowrap">図表あり</span>
+                )}
+              </span>
+            ) },
             { header: "データセット", accessor: (p) => getDatasetName(p.dataset_id) },
             { header: "ステータス", accessor: (p) => <StatusBadge status={getEffectiveProposalStatus(state, p)} /> },
             { header: "提出日", accessor: (p) => formatDate(p.created_at) },

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -181,6 +181,7 @@ export interface Proposal {
   next_steps: string;
   technical_detail: string;
   code: string;
+  charts?: DatasetGraph[];
   status: ProposalStatus;
   reviews: ReviewComment[];
   created_at: string;


### PR DESCRIPTION
## Summary
- 3つの提案（スキルマッチング・顧客セグメンテーション・経費異常検知）にChart.jsによる分析結果グラフを追加
- 提案一覧ページ（マイ提案・HRレビュー・コミュニティ）に「図表あり」タグを表示
- mainブランチとのコンフリクト（proposals.ts のID・用語変更）を解消

## Test plan
- [ ] 提案詳細ページ（SYNTH-PROP001, PROP004, PROP012）でグラフが正しく表示されること
- [ ] 一覧ページで「図表あり」タグが3提案にのみ表示されること
- [ ] グラフがない提案ではチャートセクションが表示されないこと
- [ ] HR側の詳細ページでも同様にグラフが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)