### PR TITLE
feat: さくらマート提携データの追加

### DIFF
--- a/src/data/catalog-data.ts
+++ b/src/data/catalog-data.ts
@@ -1297,6 +1297,118 @@ export const EXT_DS006_GRAPHS: DatasetGraph[] = [
   },
 ];
 
+// ============================================================
+// EXT-DS007: さくらマート 会員データ（合成） - サンプルテーブル
+// ============================================================
+
+export const EXT_DS007_SAMPLE_TABLES: SampleTable[] = [
+  {
+    tableName: "members",
+    description: "さくらマート会員の属性・購買情報を管理するテーブル",
+    columns: [
+      { name: "member_id", type: "string", displayName: "会員ID", description: "会員を一意に識別するID" },
+      { name: "name", type: "string", displayName: "氏名", description: "会員の氏名（合成データではマスク済み）" },
+      { name: "age", type: "integer", displayName: "年齢", description: "会員の年齢" },
+      { name: "gender", type: "string", displayName: "性別", description: "性別（男性/女性/その他）" },
+      { name: "postal_code", type: "string", displayName: "郵便番号", description: "会員の郵便番号（合成データでは下位桁マスク）" },
+      { name: "prefecture", type: "string", displayName: "居住都道府県", description: "会員の居住都道府県" },
+      { name: "registration_date", type: "date", displayName: "会員登録日", description: "会員カード登録日" },
+      { name: "membership_rank", type: "string", displayName: "会員ランク", description: "会員ランク（レギュラー/シルバー/ゴールド/プラチナ）" },
+      { name: "total_purchase_amount", type: "integer", displayName: "累計購買金額(円)", description: "会員の累計購買金額" },
+      { name: "visit_frequency_monthly", type: "number", displayName: "月間来店回数", description: "直近の月間平均来店回数" },
+      { name: "last_visit_date", type: "date", displayName: "最終来店日", description: "最後に来店した日付" },
+      { name: "is_active", type: "boolean", displayName: "アクティブフラグ", description: "直近3ヶ月以内に来店があるかどうか" },
+    ],
+    rows: [
+      { member_id: "SKM-00001", name: "●●●●", age: 34, gender: "女性", postal_code: "150-****", prefecture: "東京都", registration_date: "2018-05-12", membership_rank: "ゴールド", total_purchase_amount: 542000, visit_frequency_monthly: 8.5, last_visit_date: "2025-03-10", is_active: true },
+      { member_id: "SKM-00002", name: "●●●●", age: 52, gender: "男性", postal_code: "221-****", prefecture: "神奈川県", registration_date: "2015-11-03", membership_rank: "プラチナ", total_purchase_amount: 1850000, visit_frequency_monthly: 15.2, last_visit_date: "2025-03-13", is_active: true },
+      { member_id: "SKM-00003", name: "●●●●", age: 28, gender: "女性", postal_code: "330-****", prefecture: "埼玉県", registration_date: "2022-08-20", membership_rank: "レギュラー", total_purchase_amount: 78000, visit_frequency_monthly: 3.2, last_visit_date: "2025-02-28", is_active: true },
+      { member_id: "SKM-00004", name: "●●●●", age: 67, gender: "男性", postal_code: "260-****", prefecture: "千葉県", registration_date: "2012-03-15", membership_rank: "シルバー", total_purchase_amount: 320000, visit_frequency_monthly: 5.8, last_visit_date: "2024-12-20", is_active: false },
+      { member_id: "SKM-00005", name: "●●●●", age: 41, gender: "女性", postal_code: "336-****", prefecture: "埼玉県", registration_date: "2020-01-08", membership_rank: "ゴールド", total_purchase_amount: 485000, visit_frequency_monthly: 9.1, last_visit_date: "2025-03-12", is_active: true },
+    ],
+    primaryKey: ["member_id"],
+    foreignKeys: [],
+  },
+];
+
+export const EXT_DS007_USE_CASES: DatasetUseCase[] = [
+  { title: "顧客セグメント分析", description: "会員の属性・購買パターンからセグメントを自動分類し、ターゲットマーケティングの精度を向上させる。合成データにより個人を特定せずに分析が可能。", relatedGraphId: "ext-graph-member-rank" },
+  { title: "離反予測モデル", description: "来店頻度の変化や最終来店日からの経過日数を基に、会員の離反リスクを予測するモデルを構築する。", relatedGraphId: "ext-graph-member-age" },
+  { title: "クロスセル分析", description: "銀行の金融商品データと合成会員データを掛け合わせ、提携ローンやクレジットカードの効果的な訴求対象を特定する。", relatedGraphId: null },
+];
+
+export const EXT_DS007_GRAPHS: DatasetGraph[] = [
+  {
+    id: "ext-graph-member-rank",
+    title: "会員ランク分布",
+    type: "doughnut",
+    labels: ["レギュラー", "シルバー", "ゴールド", "プラチナ"],
+    datasets: [{ label: "会員数", data: [10000, 8000, 5000, 2000], backgroundColor: ["#94a3b8", "#a1a1aa", "#fbbf24", "#8b5cf6"] }],
+  },
+  {
+    id: "ext-graph-member-age",
+    title: "年代別会員数",
+    type: "bar",
+    labels: ["18-25", "25-35", "35-45", "45-55", "55-65", "65-75", "75-89"],
+    datasets: [{ label: "会員数", data: [2500, 4200, 5100, 4800, 4000, 2800, 1600], backgroundColor: "rgba(234, 88, 12, 0.6)", borderColor: "rgb(234, 88, 12)" }],
+  },
+];
+
+// ============================================================
+// EXT-DS008: さくらマート 店舗別売上データ（合成） - サンプルテーブル
+// ============================================================
+
+export const EXT_DS008_SAMPLE_TABLES: SampleTable[] = [
+  {
+    tableName: "store_daily_sales",
+    description: "さくらマート各店舗の日次売上データ",
+    columns: [
+      { name: "store_id", type: "string", displayName: "店舗ID", description: "店舗を一意に識別するID" },
+      { name: "store_name", type: "string", displayName: "店舗名", description: "店舗の名称" },
+      { name: "sales_date", type: "date", displayName: "売上日", description: "売上の対象日" },
+      { name: "total_sales", type: "integer", displayName: "売上合計(円)", description: "当日の売上合計金額" },
+      { name: "customer_count", type: "integer", displayName: "来客数", description: "当日の来客数" },
+      { name: "avg_basket_size", type: "integer", displayName: "客単価(円)", description: "当日の平均客単価" },
+      { name: "grocery_sales", type: "integer", displayName: "食料品売上(円)", description: "食料品カテゴリの売上" },
+      { name: "daily_goods_sales", type: "integer", displayName: "日用品売上(円)", description: "日用品カテゴリの売上" },
+      { name: "fresh_food_sales", type: "integer", displayName: "生鮮食品売上(円)", description: "生鮮食品カテゴリの売上" },
+      { name: "day_of_week", type: "string", displayName: "曜日", description: "売上日の曜日" },
+    ],
+    rows: [
+      { store_id: "SKM-ST01", store_name: "さくらマート 世田谷店", sales_date: "2025-03-01", total_sales: 3250000, customer_count: 1380, avg_basket_size: 2355, grocery_sales: 1850000, daily_goods_sales: 520000, fresh_food_sales: 880000, day_of_week: "土" },
+      { store_id: "SKM-ST02", store_name: "さくらマート 川崎店", sales_date: "2025-03-01", total_sales: 2680000, customer_count: 1150, avg_basket_size: 2330, grocery_sales: 1520000, daily_goods_sales: 430000, fresh_food_sales: 730000, day_of_week: "土" },
+      { store_id: "SKM-ST03", store_name: "さくらマート 浦和店", sales_date: "2025-03-01", total_sales: 1950000, customer_count: 850, avg_basket_size: 2294, grocery_sales: 1120000, daily_goods_sales: 310000, fresh_food_sales: 520000, day_of_week: "土" },
+      { store_id: "SKM-ST01", store_name: "さくらマート 世田谷店", sales_date: "2025-03-02", total_sales: 4150000, customer_count: 1620, avg_basket_size: 2562, grocery_sales: 2350000, daily_goods_sales: 680000, fresh_food_sales: 1120000, day_of_week: "日" },
+      { store_id: "SKM-ST04", store_name: "さくらマート 船橋店", sales_date: "2025-03-01", total_sales: 2120000, customer_count: 920, avg_basket_size: 2304, grocery_sales: 1200000, daily_goods_sales: 350000, fresh_food_sales: 570000, day_of_week: "土" },
+    ],
+    primaryKey: ["store_id", "sales_date"],
+    foreignKeys: [],
+  },
+];
+
+export const EXT_DS008_USE_CASES: DatasetUseCase[] = [
+  { title: "店舗パフォーマンス分析", description: "店舗別・カテゴリ別の売上トレンドを分析し、優良店舗のベストプラクティスを特定する。", relatedGraphId: "ext-graph-sales-category" },
+  { title: "需要予測モデル", description: "曜日・季節・天候データと組み合わせた需要予測モデルを構築し、在庫最適化・発注量の自動調整を実現する。", relatedGraphId: "ext-graph-sales-dow" },
+  { title: "提携ローン商圏分析", description: "店舗周辺の来客数データと銀行の支店データを掛け合わせ、提携ローンの需要ポテンシャルが高いエリアを特定する。", relatedGraphId: null },
+];
+
+export const EXT_DS008_GRAPHS: DatasetGraph[] = [
+  {
+    id: "ext-graph-sales-category",
+    title: "カテゴリ別売上構成",
+    type: "pie",
+    labels: ["食料品", "日用品", "生鮮食品"],
+    datasets: [{ label: "売上(百万円)", data: [1650, 480, 720], backgroundColor: ["rgba(59, 130, 246, 0.7)", "rgba(16, 185, 129, 0.7)", "rgba(234, 88, 12, 0.7)"] }],
+  },
+  {
+    id: "ext-graph-sales-dow",
+    title: "曜日別平均売上",
+    type: "bar",
+    labels: ["月", "火", "水", "木", "金", "土", "日"],
+    datasets: [{ label: "平均売上(万円)", data: [220, 210, 230, 215, 260, 350, 380], backgroundColor: "rgba(139, 92, 246, 0.6)", borderColor: "rgb(139, 92, 246)" }],
+  },
+];
+
 // データセットIDとカタログデータのマッピング
 // ============================================================
 
@@ -1321,4 +1433,6 @@ export const CATALOG_DATA: Record<string, {
   "EXT-DS004": { sampleTables: EXT_DS004_SAMPLE_TABLES, useCases: EXT_DS004_USE_CASES, graphs: EXT_DS004_GRAPHS },
   "EXT-DS005": { sampleTables: EXT_DS005_SAMPLE_TABLES, useCases: EXT_DS005_USE_CASES, graphs: EXT_DS005_GRAPHS },
   "EXT-DS006": { sampleTables: EXT_DS006_SAMPLE_TABLES, useCases: EXT_DS006_USE_CASES, graphs: EXT_DS006_GRAPHS },
+  "EXT-DS007": { sampleTables: EXT_DS007_SAMPLE_TABLES, useCases: EXT_DS007_USE_CASES, graphs: EXT_DS007_GRAPHS },
+  "EXT-DS008": { sampleTables: EXT_DS008_SAMPLE_TABLES, useCases: EXT_DS008_USE_CASES, graphs: EXT_DS008_GRAPHS },
 };

--- a/src/data/datasets.ts
+++ b/src/data/datasets.ts
@@ -466,4 +466,84 @@ export const DATASETS: Dataset[] = [
       { column_name: "helpful_count", inferred_type: "integer", is_pii: false, pii_reason: null, description: "参考になった数", stats: { count: 100000, null_count: 0, unique_count: 200, min: 0, max: 500, mean: 8.5, std: 22.3 } },
     ],
   },
+  // ============================================================
+  // EXT-DS007: さくらマート 会員データ（合成）
+  // ============================================================
+  {
+    dataset_id: "EXT-DS007",
+    name: "さくらマート 会員データ（合成）",
+    owner_user_id: "external_provider",
+    is_published: true,
+    source: "external",
+    provider: "さくらマートホールディングス株式会社",
+    price_info: "データ共有提携（非売品）",
+    description: "提携先スーパーマーケット「さくらマート」の会員データ。個人情報を含むため、合成データ化してから分析に利用する。年齢・性別・居住地域・来店頻度・累計購買金額などの属性を含み、顧客セグメント分析やマーケティング施策の検討に活用可能。",
+    tags: ["提携", "会員", "スーパーマーケット", "PII"],
+    created_at: "2025-03-15T09:00:00Z",
+    files: [
+      { file_type: "employee_master", file_path: "data/EXT-DS007/member_master.csv", created_at: "2025-03-15T09:00:00Z" },
+    ],
+    synthetic_artifacts: [
+      { file_type: "employee_master", file_path: "synthetic/EXT-DS007/member_master_seed42.csv", seed: 42, created_at: "2025-03-20T10:00:00Z" },
+    ],
+    quality_report: {
+      overall_score: 0.93,
+      file_reports: [
+        { file_type: "employee_master", row_count_original: 25000, row_count_synthetic: 25000, column_correlation: 0.94, distribution_similarity: 0.92, statistical_parity: 0.93 },
+      ],
+    },
+    catalog: [
+      { column_name: "member_id", inferred_type: "string", is_pii: true, pii_reason: "会員ID", description: "会員を一意に識別するID", stats: { count: 25000, null_count: 0, unique_count: 25000 } },
+      { column_name: "name", inferred_type: "string", is_pii: true, pii_reason: "氏名", description: "会員氏名", stats: { count: 25000, null_count: 0, unique_count: 24800 } },
+      { column_name: "age", inferred_type: "integer", is_pii: false, pii_reason: null, description: "年齢", stats: { count: 25000, null_count: 0, unique_count: 72, min: 18, max: 89, mean: 45.2, std: 15.8, histogram: { bins: ["18-25", "25-35", "35-45", "45-55", "55-65", "65-75", "75-89"], counts: [2500, 4200, 5100, 4800, 4000, 2800, 1600] } } },
+      { column_name: "gender", inferred_type: "string", is_pii: false, pii_reason: null, description: "性別", stats: { count: 25000, null_count: 0, unique_count: 3 } },
+      { column_name: "postal_code", inferred_type: "string", is_pii: true, pii_reason: "郵便番号", description: "会員の郵便番号", stats: { count: 25000, null_count: 0, unique_count: 3200 } },
+      { column_name: "prefecture", inferred_type: "string", is_pii: false, pii_reason: null, description: "居住都道府県", stats: { count: 25000, null_count: 0, unique_count: 15 } },
+      { column_name: "registration_date", inferred_type: "date", is_pii: false, pii_reason: null, description: "会員登録日", stats: { count: 25000, null_count: 0, unique_count: 2800, min: "2010-04-01", max: "2025-03-01" } },
+      { column_name: "membership_rank", inferred_type: "string", is_pii: false, pii_reason: null, description: "会員ランク（レギュラー/シルバー/ゴールド/プラチナ）", stats: { count: 25000, null_count: 0, unique_count: 4 } },
+      { column_name: "total_purchase_amount", inferred_type: "integer", is_pii: false, pii_reason: null, description: "累計購買金額(円)", stats: { count: 25000, null_count: 0, unique_count: 20000, min: 500, max: 3500000, mean: 285000, std: 320000, histogram: { bins: ["0-50000", "50000-100000", "100000-300000", "300000-500000", "500000-1000000", "1000000+"], counts: [3500, 4200, 8500, 4800, 2500, 1500] } } },
+      { column_name: "visit_frequency_monthly", inferred_type: "number", is_pii: false, pii_reason: null, description: "月間来店回数", stats: { count: 25000, null_count: 0, unique_count: 200, min: 0.5, max: 25, mean: 6.8, std: 4.2, histogram: { bins: ["0-2", "2-5", "5-10", "10-15", "15-25"], counts: [2000, 6500, 9000, 5000, 2500] } } },
+      { column_name: "last_visit_date", inferred_type: "date", is_pii: false, pii_reason: null, description: "最終来店日", stats: { count: 25000, null_count: 0, unique_count: 365, min: "2024-01-15", max: "2025-03-14" } },
+      { column_name: "is_active", inferred_type: "boolean", is_pii: false, pii_reason: null, description: "アクティブフラグ", stats: { count: 25000, null_count: 0, unique_count: 2 } },
+    ],
+  },
+  // ============================================================
+  // EXT-DS008: さくらマート 店舗別売上データ（合成）
+  // ============================================================
+  {
+    dataset_id: "EXT-DS008",
+    name: "さくらマート 店舗別売上データ（合成）",
+    owner_user_id: "external_provider",
+    is_published: true,
+    source: "external",
+    provider: "さくらマートホールディングス株式会社",
+    price_info: "データ共有提携（非売品）",
+    description: "提携先「さくらマート」の関東圏45店舗における日次売上データ。カテゴリ別売上・客数・客単価を含み、店舗パフォーマンス分析や需要予測モデルの構築に活用可能。合成データ化により安全にデータ分析が可能。",
+    tags: ["提携", "売上", "店舗", "スーパーマーケット"],
+    created_at: "2025-03-15T09:00:00Z",
+    files: [
+      { file_type: "employee_master", file_path: "data/EXT-DS008/store_daily_sales.csv", created_at: "2025-03-15T09:00:00Z" },
+    ],
+    synthetic_artifacts: [
+      { file_type: "employee_master", file_path: "synthetic/EXT-DS008/store_daily_sales_seed42.csv", seed: 42, created_at: "2025-03-20T10:00:00Z" },
+    ],
+    quality_report: {
+      overall_score: 0.91,
+      file_reports: [
+        { file_type: "employee_master", row_count_original: 16425, row_count_synthetic: 16425, column_correlation: 0.92, distribution_similarity: 0.90, statistical_parity: 0.91 },
+      ],
+    },
+    catalog: [
+      { column_name: "store_id", inferred_type: "string", is_pii: false, pii_reason: null, description: "店舗ID", stats: { count: 16425, null_count: 0, unique_count: 45 } },
+      { column_name: "store_name", inferred_type: "string", is_pii: false, pii_reason: null, description: "店舗名", stats: { count: 16425, null_count: 0, unique_count: 45 } },
+      { column_name: "sales_date", inferred_type: "date", is_pii: false, pii_reason: null, description: "売上日", stats: { count: 16425, null_count: 0, unique_count: 365, min: "2024-04-01", max: "2025-03-31" } },
+      { column_name: "total_sales", inferred_type: "integer", is_pii: false, pii_reason: null, description: "売上合計(円)", stats: { count: 16425, null_count: 0, unique_count: 16000, min: 450000, max: 8500000, mean: 2850000, std: 1200000, histogram: { bins: ["0-1M", "1M-2M", "2M-3M", "3M-5M", "5M+"], counts: [1200, 3800, 5500, 4200, 1725] } } },
+      { column_name: "customer_count", inferred_type: "integer", is_pii: false, pii_reason: null, description: "来客数", stats: { count: 16425, null_count: 0, unique_count: 3000, min: 150, max: 3500, mean: 1200, std: 520, histogram: { bins: ["0-500", "500-1000", "1000-1500", "1500-2000", "2000+"], counts: [1500, 4000, 5500, 3500, 1925] } } },
+      { column_name: "avg_basket_size", inferred_type: "integer", is_pii: false, pii_reason: null, description: "客単価(円)", stats: { count: 16425, null_count: 0, unique_count: 2500, min: 1200, max: 4500, mean: 2375, std: 480, histogram: { bins: ["1000-1500", "1500-2000", "2000-2500", "2500-3000", "3000+"], counts: [1200, 3500, 5800, 4000, 1925] } } },
+      { column_name: "grocery_sales", inferred_type: "integer", is_pii: false, pii_reason: null, description: "食料品売上(円)", stats: { count: 16425, null_count: 0, unique_count: 15000, min: 200000, max: 5000000, mean: 1650000, std: 720000 } },
+      { column_name: "daily_goods_sales", inferred_type: "integer", is_pii: false, pii_reason: null, description: "日用品売上(円)", stats: { count: 16425, null_count: 0, unique_count: 12000, min: 50000, max: 1500000, mean: 480000, std: 210000 } },
+      { column_name: "fresh_food_sales", inferred_type: "integer", is_pii: false, pii_reason: null, description: "生鮮食品売上(円)", stats: { count: 16425, null_count: 0, unique_count: 14000, min: 100000, max: 2500000, mean: 720000, std: 380000 } },
+      { column_name: "day_of_week", inferred_type: "string", is_pii: false, pii_reason: null, description: "曜日", stats: { count: 16425, null_count: 0, unique_count: 7 } },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- 提携先スーパーマーケット「さくらマート」の2データセットを追加
  - **EXT-DS007**: 会員データ（25,000件、PII含む、合成データ品質スコア0.93）
  - **EXT-DS008**: 店舗別売上データ（45店舗×365日、合成データ品質スコア0.91）
- 既存の外部データと異なり、提携データとして合成データ生成・品質レポート付き
- サンプルデータでは氏名・郵便番号を匿名化し、安全なデータ共有をデモ

## Test plan
- [ ] `npm run build` が成功すること
- [ ] 社外データカタログ一覧にさくらマートの2データセットが表示されること
- [ ] 各データセットの詳細ページでサンプルテーブル・ユースケース・グラフが表示されること
- [ ] 合成データ品質レポートが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)